### PR TITLE
aft version update

### DIFF
--- a/examples/github+tf_oss/main.tf
+++ b/examples/github+tf_oss/main.tf
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 module "aft" {
-  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory"
+  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.12.0"
   # Required Vars
-  ct_management_account_id    = "111122223333"
-  log_archive_account_id      = "444455556666"
-  audit_account_id            = "123456789012"
-  aft_management_account_id   = "777788889999"
-  ct_home_region              = "us-east-1"
-  tf_backend_secondary_region = "us-west-2"
+  ct_management_account_id    = "316689970579"
+  log_archive_account_id      = "903296247028"
+  audit_account_id            = "764660151821"
+  aft_management_account_id   = "891377100111"
+  ct_home_region              = "eu-west-1"
+  tf_backend_secondary_region = "eu-central-1"
   # VCS Vars
   vcs_provider                                  = "github"
-  account_request_repo_name                     = "ExampleOrg/example-repo-1"
-  global_customizations_repo_name               = "ExampleOrg/example-repo-2"
-  account_customizations_repo_name              = "ExampleOrg/example-repo-3"
-  account_provisioning_customizations_repo_name = "ExampleOrg/example-repo-4"
+  account_request_repo_name                     = "DevoteamNL/aft-account-request"
+  global_customizations_repo_name               = "DevoteamNL/aft-global-customizations"
+  account_customizations_repo_name              = "DevoteamNL/aft-account-customizations"
+  account_provisioning_customizations_repo_name = "DevoteamNL/aft-provisioning-customizations"
 }
+

--- a/examples/github+tf_oss/main.tf
+++ b/examples/github+tf_oss/main.tf
@@ -16,5 +16,7 @@ module "aft" {
   global_customizations_repo_name               = "DevoteamNL/aft-global-customizations"
   account_customizations_repo_name              = "DevoteamNL/aft-account-customizations"
   account_provisioning_customizations_repo_name = "DevoteamNL/aft-provisioning-customizations"
+
+  aft_enable_vpc = false
 }
 


### PR DESCRIPTION
- **feat: update and pin aft module to 1.12.0**
- **feat: disable management account vpc**

this version update enables us to disable the aft management vpc that deploys 16 vpc endpoints which used to cost us around 200USD every month

<img width="1370" alt="image" src="https://github.com/DevoteamNL/terraform-aws-control_tower_account_factory/assets/33603535/f182bfb0-131c-4aec-8129-aa3f573d2a63">

## Before Today
<img width="1446" alt="image" src="https://github.com/DevoteamNL/terraform-aws-control_tower_account_factory/assets/33603535/cc454f93-5dc7-4ce7-b514-b5cdb64c1597">

<img width="1467" alt="image" src="https://github.com/DevoteamNL/terraform-aws-control_tower_account_factory/assets/33603535/6c4f0e5a-babf-47d7-a4a0-4fa4f6bdf290">

## Today

<img width="684" alt="image" src="https://github.com/DevoteamNL/terraform-aws-control_tower_account_factory/assets/33603535/835d9202-6adc-4bcf-828e-8e8c74656ec3">

<img width="1447" alt="image" src="https://github.com/DevoteamNL/terraform-aws-control_tower_account_factory/assets/33603535/16f4fa4e-119f-40c4-baf3-eac5f423a982">




