### PR TITLE
feat: migrate state using parameterized s3 backend

### DIFF
--- a/examples/github+tf_oss/main.tf
+++ b/examples/github+tf_oss/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+
+  backend "s3" {}
+}
 # Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/examples/github+tf_oss/s3_backend.hcl
+++ b/examples/github+tf_oss/s3_backend.hcl
@@ -1,0 +1,3 @@
+key    = "github-tf-oss-state/terraform.tfstate"
+bucket = "devoteam-mgmt-aft-terraform-state"
+region = "eu-west-1"


### PR DESCRIPTION
- This PR allows us to use the s3 backend instead of the default local backend for the terraform operations in the root aft module.
- Here is a screenshot from the directory structure inside the bucket
<img width="1138" alt="image" src="https://github.com/DevoteamNL/terraform-aws-control_tower_account_factory/assets/33603535/67f00568-faaa-4ac0-9377-38cfc78e2068">
